### PR TITLE
By default disable activity linking plugin Add plasma-nm  to tray if available Symlink network plasma theme icon to plasma-nm, so it  doesn't fallback to Air

### DIFF
--- a/config-files/etc/kde4/share/config/kservicemenurc
+++ b/config-files/etc/kde4/share/config/kservicemenurc
@@ -1,0 +1,2 @@
+[Show]
+kactivitymanagerd_fileitem_linking_plugin=false

--- a/config-files/usr/share/kde4/apps/desktoptheme/openSUSE/icons/plasma-nm.svgz
+++ b/config-files/usr/share/kde4/apps/desktoptheme/openSUSE/icons/plasma-nm.svgz
@@ -1,0 +1,1 @@
+network.svgz

--- a/config-files/usr/share/kde4/apps/plasma-desktop/updates/10-opensuse-plasmanm.js
+++ b/config-files/usr/share/kde4/apps/plasma-desktop/updates/10-opensuse-plasmanm.js
@@ -1,0 +1,48 @@
+/*
+   10-opensuse-plasmanm.js - Add NM plasmoid to the systray
+   lifted and adapted from fedora by Hrvoje Senjan <hrvoje.senjan@gmail.com>
+   Copyright (C) 2010 Kevin Kofler <kevin.kofler@chello.at>
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 2 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+   Portions lifted from 01-kubuntu-10.04.js:
+   Harald Sitter, apachelogger@ubuntu.com 2010-04-02
+   Jonathan Riddell, jriddell@ubuntu.com 2010-02-18
+   Copyright Canonical Ltd, may be copied under the GNU GPL 2 or later
+*/
+
+systrayFound = false;
+pids = panelIds;
+for (i = 0; i < pids.length; ++i) {
+  p = panelById(pids[i]);
+  if (!p) continue;
+  ids = p.widgetIds;
+  for (j = 0; j < ids.length; ++j) {
+    w = p.widgetById(ids[j]);
+    if (!w || w.type != "systemtray") continue;
+    systrayFound = true;
+    w.currentConfigGroup = new Array("Applets");
+    max = 0;
+    for (k = 0; k < w.configGroups.length; ++k)
+      if (parseInt(w.configGroups[k]) > max)
+        max = parseInt(w.configGroups[k]);
+    w.currentConfigGroup = new Array("Applets", max + 1);
+    w.writeConfig("plugin", "org.kde.plasma-nm");
+    print("Network management plasmoid added to the systray");
+    break;
+  }
+  if (systrayFound) break;
+}
+if (!systrayFound)
+  print("No systray found");


### PR DESCRIPTION
By default disable activity linking plugin Add plasma-nm
 to tray if available Symlink network plasma theme icon to plasma-nm, so it
 doesn't fallback to Air
